### PR TITLE
exclude test in report if reference has failed subtests in test

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,9 +349,18 @@ var consolidate = function (_consolidated, _out) {
         for (var i = 0, n = _consolidated[agent].results.length; i < n; i++) {
             var testData = _consolidated[agent].results[i]
             ,   id = testData.test
+            ,   hasFailedSubtests = false;
             ;
             if (filter.excludeFile(id)) continue;
             if (!testData.subtests.length && filter.excludeCase(id, id)) continue; // manual/reftests
+            for (var k = 0; k < testData.subtests.length; k++) {
+                var subtest = testData.subtests[k];
+                if (filter.excludeCase(id, subtest.name)) {
+                    hasFailedSubtests = true;
+                    break;
+                }
+            }
+            if (hasFailedSubtests) continue; // exclude test in report if reference has failed subtests in test
             if (!_out.results[id]) {
                 _out.results[id] = {
                     byUA:       {}


### PR DESCRIPTION
Not only subtests will be excluded in the report if it failed in a reference browser, but the complete test as soon as one subtest failed in one of the references.